### PR TITLE
Configure multi feature crate

### DIFF
--- a/build/rust/Cargo.toml
+++ b/build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.0"
-name = "tucana-internal"
+name = "tucana"
 edition = "2021"
 description = "The rust crate for the internal gRPC communication of Code0"
 repository = "https://github.com/code0-tech/tucana"
@@ -20,7 +20,7 @@ serde_json = "1.0.120"
 tonic-build = "0.12.1"
 
 [lib]
-name = "tucana_internal"
+name = "tucana"
 path = "src/lib.rs"
 
 [features]

--- a/build/rust/Cargo.toml
+++ b/build/rust/Cargo.toml
@@ -22,3 +22,9 @@ tonic-build = "0.12.1"
 [lib]
 name = "tucana_internal"
 path = "src/lib.rs"
+
+[features]
+shared = []
+aquila = ["shared"]
+sagittarius = ["shared"]
+all = ["aquila", "sagittarius"]

--- a/build/rust/src/lib.rs
+++ b/build/rust/src/lib.rs
@@ -1,11 +1,14 @@
+#[cfg(feature = "sagittarius")]
 pub mod sagittarius {
     include!("generated/sagittarius.rs");
 }
 
+#[cfg(feature = "aquila")]
 pub mod aquila {
     include!("generated/aquila.rs");
 }
 
+#[cfg(feature = "shared")]
 pub mod shared {
     include!("generated/shared.rs");
 }


### PR DESCRIPTION
Splits every module into a feature. If one isn't needed e.g. aquila proto in the execution you can exclude it from the dependencies

Resolves #11