### PR TITLE
Fix translation usage in data type

### DIFF
--- a/proto/shared/datatype_definition.proto
+++ b/proto/shared/datatype_definition.proto
@@ -18,8 +18,8 @@ message DataType {
     FUNCTION = 7;
   }
 
-  Translation name = 1;
-  Variant variant = 2;
+  Variant variant = 1;
+  repeated Translation name = 2;
   repeated DataTypeRule rules = 3;
   repeated DataType input_types = 4;
   optional DataType return_type = 5;


### PR DESCRIPTION
A datatype can have multiple translations (one for each language), so this needs to be a repeated field