### PR TITLE
Added Reference Path

### DIFF
--- a/build/rust/build.rs
+++ b/build/rust/build.rs
@@ -66,6 +66,7 @@ fn main() -> Result<()> {
         .type_attribute("kind", serde_attribute)
         .type_attribute("value", serde_attribute)
         .type_attribute("config", serde_attribute)
+        .type_attribute("ReferencePath", serde_attribute)
         .type_attribute("ReferenceValue", serde_attribute)
         .type_attribute("NullValue", serde_attribute)
         .type_attribute("Value", serde_attribute)

--- a/proto/shared/shared.flow.proto
+++ b/proto/shared/shared.flow.proto
@@ -49,7 +49,12 @@ message ReferenceValue {
     int32 primary_level = 2;
     int32 secondary_level = 3;
     optional int32 tertiary_level = 4;
-    string path = 5;
+    repeated ReferencePath paths = 5;
+ }
+
+ message ReferencePath {
+     optional string path = 1;
+     optional string array_index = 2;
  }
 
 message NodeParameterDefinition {


### PR DESCRIPTION
Should Resolve: #87

@Taucher2003 if you can make shure, the list of paths is ordered (in a logical way) the draft can be turned into a pull request and no changes are needed. If not what do we need to adjust?

What do I mean by ordered:

```json
 {
   "persons": [
    {
     "name": "Tom"
    },
    {
     "name": Thomas"
    }
  ]
}
```

If I want to reference the second name I first need a reference posting to the path (e.g. persons) then another reference for the index and the path of the name. If this isn't ordered, I will not be able to reach the wanted reference! 