### PR TITLE
Add cast field for NodeParameters

### DIFF
--- a/proto/shared/shared.flow.proto
+++ b/proto/shared/shared.flow.proto
@@ -62,6 +62,7 @@ message NodeParameter {
   int64 database_id = 1;
   string runtime_parameter_id = 2;
   NodeValue value = 3;
+  optional string cast = 4;
 }
 
 message ReferenceValue {

--- a/proto/shared/shared.flow.proto
+++ b/proto/shared/shared.flow.proto
@@ -37,6 +37,7 @@ message FlowSetting {
   int64 database_id = 1;
   string flow_setting_id = 2;
   shared.Value value = 3;
+  optional string cast = 4;
 }
 
 message NodeFunction {


### PR DESCRIPTION
Close #273 

This is needed for the possibility to allow the user to parse in a type as a parameter